### PR TITLE
depend on latest (3.4.0) jna release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>3.0.9</version>
+      <version>3.4.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Hey Kohsuke, is there a reason not to depend on the latest JNA version (for the next release) ?

We've (e.g. trinidad/trinidad_daemon_extension#4) seen: **java.lang.UnsatisfiedLinkError** 
`Unable to load library 'c': /usr/lib/i386-linux-gnu/libc.so: invalid ELF header`
that has gone away somewhere between 3.1.0 and 3.4.0 ...
