### PR TITLE
Fix reading the command line arguments on 64bit, little-endian Solaris systems

### DIFF
--- a/src/main/java/com/sun/akuma/JavaVMArguments.java
+++ b/src/main/java/com/sun/akuma/JavaVMArguments.java
@@ -278,7 +278,7 @@ public class JavaVMArguments extends ArrayList<String> {
                     | ((i>> 8) & 0x00000000FF000000L)
                     | ((i>>24) & 0x0000000000FF0000L)
                     | ((i>>40) & 0x000000000000FF00L)
-                    | (i>>56);
+                    | (i>>>56);
         else
             return i;
     }


### PR DESCRIPTION
Reading the command line arguments often fails on Solaris x64, because of a bug in the big-endian to little-endian conversion code.